### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ store = []
 docs = []
 
 [dependencies]
-goblin = "0"
+goblin = "0.6"
 thiserror = "1"
-ouroboros = "0"
-sealed = "0"
+ouroboros = "0.15"
+sealed = "0.4"
 
 [dev-dependencies]
 libloading = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ ouroboros = "0.15"
 sealed = "0.4"
 
 [dev-dependencies]
-libloading = "0"
+libloading = "0.7"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.